### PR TITLE
fix(cache): keep chart duration on refresh + count ttl breakdown

### DIFF
--- a/backend-go/internal/handlers/responses/handler.go
+++ b/backend-go/internal/handlers/responses/handler.go
@@ -540,10 +540,13 @@ func handleSuccess(
 
 	// 返回 usage 数据用于指标记录
 	return &types.Usage{
-		InputTokens:              responsesResp.Usage.InputTokens,
-		OutputTokens:             responsesResp.Usage.OutputTokens,
-		CacheCreationInputTokens: responsesResp.Usage.CacheCreationInputTokens,
-		CacheReadInputTokens:     responsesResp.Usage.CacheReadInputTokens,
+		InputTokens:                responsesResp.Usage.InputTokens,
+		OutputTokens:               responsesResp.Usage.OutputTokens,
+		CacheCreationInputTokens:   responsesResp.Usage.CacheCreationInputTokens,
+		CacheReadInputTokens:       responsesResp.Usage.CacheReadInputTokens,
+		CacheCreation5mInputTokens: responsesResp.Usage.CacheCreation5mInputTokens,
+		CacheCreation1hInputTokens: responsesResp.Usage.CacheCreation1hInputTokens,
+		CacheTTL:                   responsesResp.Usage.CacheTTL,
 	}
 }
 
@@ -831,10 +834,13 @@ func handleStreamSuccess(
 
 	// 返回收集到的 usage 数据
 	return &types.Usage{
-		InputTokens:              collectedUsage.InputTokens,
-		OutputTokens:             collectedUsage.OutputTokens,
-		CacheCreationInputTokens: collectedUsage.CacheCreationInputTokens,
-		CacheReadInputTokens:     collectedUsage.CacheReadInputTokens,
+		InputTokens:                collectedUsage.InputTokens,
+		OutputTokens:               collectedUsage.OutputTokens,
+		CacheCreationInputTokens:   collectedUsage.CacheCreationInputTokens,
+		CacheReadInputTokens:       collectedUsage.CacheReadInputTokens,
+		CacheCreation5mInputTokens: collectedUsage.CacheCreation5mInputTokens,
+		CacheCreation1hInputTokens: collectedUsage.CacheCreation1hInputTokens,
+		CacheTTL:                   collectedUsage.CacheTTL,
 	}
 }
 

--- a/backend-go/internal/metrics/channel_metrics.go
+++ b/backend-go/internal/metrics/channel_metrics.go
@@ -300,7 +300,11 @@ func (m *MetricsManager) RecordSuccessWithUsage(baseURL, apiKey string, usage *t
 	if usage != nil {
 		inputTokens = int64(usage.InputTokens)
 		outputTokens = int64(usage.OutputTokens)
+		// cache_creation_input_tokens 有时不会返回（只返回 5m/1h 细分字段），这里做兜底汇总。
 		cacheCreationTokens = int64(usage.CacheCreationInputTokens)
+		if cacheCreationTokens <= 0 {
+			cacheCreationTokens = int64(usage.CacheCreation5mInputTokens + usage.CacheCreation1hInputTokens)
+		}
 		cacheReadTokens = int64(usage.CacheReadInputTokens)
 	}
 


### PR DESCRIPTION
修复 Web UI Key 趋势图(缓存 R/W)在切换 1h/6h/24h 后不刷新、手动刷新后回到默认 1h 的问题，并补齐缓存创建统计在仅返回 TTL 细分字段时的兜底汇总。\n\n- 前端：KeyTrendChart 持久化 view/duration 到 localStorage，避免组件重建丢状态；并加入 requestId 防止自动刷新旧响应覆盖新选择。\n- 后端：RecordSuccessWithUsage 在 cache_creation_input_tokens 缺失/为 0 时，汇总 cache_creation_{5m,1h}_input_tokens 作为 cacheCreationTokens。\n- Responses：非流式/流式 usage 透传 CacheCreation5m/1h + CacheTTL 到指标层。\n- 测试：新增用例覆盖 TTL 细分字段兜底。